### PR TITLE
communicate between plugin and controller and modify CMakeLists.txt for introducing NLOPT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 include(FindPkgConfig)
 pkg_check_modules(cnoid-plugin REQUIRED choreonoid-body-plugin)
 pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
+pkg_check_modules(NLOPT REQUIRED nlopt)
 
 catkin_package(
   DEPENDS
@@ -21,8 +22,8 @@ catkin_package(
   LIBRARIES # TODO
 )
 
-include_directories(${cnoid-plugin_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${YAML_CPP_INCLUDEDIR})
-link_directories(${cnoid-plugin_LIBRARY_DIRS} ${catkin_LIBRARY_DIRS})
+include_directories(${cnoid-plugin_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${YAML_CPP_INCLUDEDIR} ${NLOPT_INCLUDE_DIRS})
+link_directories(${cnoid-plugin_LIBRARY_DIRS} ${catkin_LIBRARY_DIRS} ${NLOPT_LIBRARY_DIRS})
 
 ### Customizer ###
 set(target CnoidTrampolineCustomizer)
@@ -55,7 +56,7 @@ set_target_properties(${target} PROPERTIES
 
 set(target CnoidPDController_InvertedPendulum)
 add_library(${target} SHARED controllers/PDController_InvertedPendulum.cpp)
-target_link_libraries(${target} ${cnoid-plugin_LIBRARIES})
+target_link_libraries(${target} ${cnoid-plugin_LIBRARIES} rt)
 set_target_properties(${target} PROPERTIES
   COMPILE_FLAG "-fPIC"
   PREFIX "lib"
@@ -73,7 +74,7 @@ set_target_properties(${target} PROPERTIES
 
 set(target CnoidOptimizeGainPlugin)
 add_library(${target} SHARED plugins/OptimizeGainPlugin.cpp)
-target_link_libraries(${target} ${cnoid-plugin_LIBRARIES})
+target_link_libraries(${target} ${cnoid-plugin_LIBRARIES} ${NLOPT_LIBRARIES} rt)
 set_target_properties(${target} PROPERTIES
   PREFIX "lib"
   SUFFIX ".so"

--- a/plugins/OptimizeGainPlugin.cpp
+++ b/plugins/OptimizeGainPlugin.cpp
@@ -46,7 +46,6 @@ private:
     {
         if (simulator_item_) {
             if (simulator_item_->simulationTime() > reset_interval_) {
-                simulator_item_->startSimulation(true);
 
                 shared_memory_object shm_gain{open_or_create, "Gain", read_write};
                 shm_gain.truncate(1024);
@@ -60,7 +59,9 @@ private:
                 mapped_region region_eval{shm_eval, read_only};
                 double *eval = static_cast<double*>(region_eval.get_address());
                 for (int i = 0; i < 1; i++)
-                    MessageView::mainInstance()->putln(std::to_string(eval[i])); // 0.0が表示される？
+                    MessageView::mainInstance()->putln(std::string("eval: ") + std::to_string(eval[i]));
+
+                simulator_item_->startSimulation(true);
             }
         } else {
             ItemPtr robot_item = RootItem::instance()->findItem("InvertedPendulum");

--- a/plugins/OptimizeGainPlugin.cpp
+++ b/plugins/OptimizeGainPlugin.cpp
@@ -1,9 +1,9 @@
 // -*- mode: C++; coding: utf-8-unix; -*-
 
 /**
- * @file  ResetSimulation.cpp
- * @brief Reset the simulation at regular intervals
- * @author Tatsuya Ishikawa
+ * @file  OptimizeGainPlugin.cpp
+ * @brief Reset the simulation at regular intervals and optimize gains with nlopt
+ * @author Hiroki Takeda
  */
 
 #include <cnoid/Plugin>


### PR DESCRIPTION
plugin側でeval値が読めなかった問題はシミュレーションを初期化するタイミングの問題でしたので修正しました．
現在，pluginからcontrollerへの決め打ち値のgain受け渡しと
controllerからpluginへの評価値の受け渡しができています．

また，nloptをリンクしてコンパイルできるようにCMakeLists.txtを修正しました．