### PR TITLE
Add toggle button and spinbox to change on/off, interval of ResetSimulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ find_package(catkin COMPONENTS
   jsk_models
   )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(FindPkgConfig)
 pkg_check_modules(cnoid-plugin REQUIRED choreonoid-body-plugin)
@@ -64,13 +66,13 @@ set_target_properties(${target} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 ### Plugin ###
-# set(target CnoidResetSimulationPlugin)
-# add_library(${target} SHARED plugins/ResetSimulationPlugin.cpp)
-# target_link_libraries(${target} ${cnoid-plugin_LIBRARIES})
-# set_target_properties(${target} PROPERTIES
-#   PREFIX "lib"
-#   SUFFIX ".so"
-#   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
+set(target CnoidResetSimulationPlugin)
+add_library(${target} SHARED plugins/ResetSimulationPlugin.cpp)
+target_link_libraries(${target} ${cnoid-plugin_LIBRARIES})
+set_target_properties(${target} PROPERTIES
+  PREFIX "lib"
+  SUFFIX ".so"
+  LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 set(target CnoidOptimizeGainPlugin)
 add_library(${target} SHARED plugins/OptimizeGainPlugin.cpp)

--- a/plugins/ResetSimulationPlugin.cpp
+++ b/plugins/ResetSimulationPlugin.cpp
@@ -14,6 +14,8 @@
 #include <cnoid/ToolBar>
 #include <cnoid/SpinBox>
 
+#include "../util/util.h"
+
 using namespace cnoid;
 
 class ResetSimulationPlugin : public Plugin
@@ -60,7 +62,7 @@ private:
             if (simulator_item_->simulationTime() > reset_interval_)
                 simulator_item_->startSimulation(true);
         } else {
-            simulator_item_ = dynamic_cast<SimulatorItem*>(RootItem::instance()->findItem("AISTSimulator"));
+            simulator_item_ = findSimulatorItem("AISTSimulator");
             if (!simulator_item_) {
                 MessageView::mainInstance()->putln("[ResetSimulationPlugin] Simulator item can't be found. Stop reset_timer_");
                 reset_timer_.stop();

--- a/util/util.h
+++ b/util/util.h
@@ -1,0 +1,15 @@
+// -*- mode: C++; coding: utf-8-unix; -*-
+
+#ifndef __CHOREONOID_PLUGINS_UTIL_H__
+#define __CHOREONOID_PLUGINS_UTIL_H__
+
+#include <string>
+#include <cnoid/RootItem>
+#include <cnoid/SimulatorItem>
+
+cnoid::SimulatorItem* findSimulatorItem(const std::string& simulator_name = "AISTSimulator")
+{
+    return dynamic_cast<cnoid::SimulatorItem*>(cnoid::RootItem::instance()->findItem(simulator_name));
+}
+
+#endif // __CHOREONOID_PLUGINS_UTIL_H__


### PR DESCRIPTION
@jskhtakeda watchしてなさそうなのでとりあえず今の時期はwatchしておいてください
ResetSimulationPluginの改良をしました．
- Toggle buttonでresetの ON / OFFを切り替えられる
- spinboxで時間を変更できる
- findActiveSimulatorItemForを使わず，AISTSimulatorを探しに行くようにした
- make_uniqueを使うためC++14にした

TODO: OptimizeGainPlugin.cppみたいにResetが必要なPluginにいちいちResetSimulationPluginの実装をコピーするのをやめる
案： simulatorItemのsigSimulationFinished()を使う．起動順の関係でfindSimulatorItemが少しややこしくなりそう