### PR TITLE
[plugins/OptimizeGainPlugin.cpp] Use sigSimulationFinished instead of reset timer

### DIFF
--- a/plugins/OptimizeGainPlugin.cpp
+++ b/plugins/OptimizeGainPlugin.cpp
@@ -23,54 +23,54 @@ using namespace cnoid;
 class OptimizeGainPlugin : public Plugin
 {
     SimulatorItemPtr simulator_item_;
-    Timer reset_timer_;
-    double reset_interval_;
-public:
+    shared_memory_object shm_gain{};
+    shared_memory_object shm_eval{};
+    const char* GAIN_SHM = "Gain";
+    const char* EVAL_SHM = "Eval";
 
+  public:
     OptimizeGainPlugin() : Plugin("OptimizeGain")
     {
+        require("Body");
     }
 
     virtual bool initialize() override
     {
-        reset_timer_.sigTimeout().connect([this]() { resetSimulation(); });
-        reset_timer_.setInterval(100); // 100ms
-        reset_timer_.start();
-        reset_interval_ = 3; // sec
+        shm_gain = shared_memory_object{create_only, GAIN_SHM, read_write};
+        shm_gain.truncate(1024);
+        shm_eval = shared_memory_object{create_only, EVAL_SHM, read_write};
+        shm_eval.truncate(1024);
+
+        cnoid::RootItem::instance()->sigItemAdded().connect([this](Item* _item) {
+                SimulatorItemPtr itemptr = dynamic_cast<cnoid::SimulatorItem*>(_item);
+                if (itemptr) {
+                    this->simulator_item_ = itemptr;
+                    this->simulator_item_->sigSimulationFinished().connect([this]() { this->evalNLOPT(); });
+                }
+            });
         return true;
     }
 
-private:
-
-    void resetSimulation()
+    virtual bool finalize() override
     {
-        if (simulator_item_) {
-            if (simulator_item_->simulationTime() > reset_interval_) {
+        shm_gain.remove(GAIN_SHM);
+        shm_eval.remove(EVAL_SHM);
+        return true;
+    }
 
-                shared_memory_object shm_gain{open_or_create, "Gain", read_write};
-                shm_gain.truncate(1024);
-                mapped_region region_gain{shm_gain, read_write};
-                double *gain = static_cast<double*>(region_gain.get_address());
-                for (int i = 0; i < 4; i++)
-                    gain[i] = 0.01 * i;
+  private:
 
-                shared_memory_object shm_eval{open_or_create, "Eval", read_write};
-                shm_eval.truncate(1024);
-                mapped_region region_eval{shm_eval, read_only};
-                double *eval = static_cast<double*>(region_eval.get_address());
-                for (int i = 0; i < 1; i++)
-                    MessageView::mainInstance()->putln(std::string("eval: ") + std::to_string(eval[i]));
+    void evalNLOPT()
+    {
+        mapped_region region_gain{shm_gain, read_write};
+        double *gain = static_cast<double*>(region_gain.get_address());
+        for (int i = 0; i < 4; i++)
+            gain[i] = 0.01 * i;
 
-                simulator_item_->startSimulation(true);
-            }
-        } else {
-            ItemPtr robot_item = RootItem::instance()->findItem("InvertedPendulum");
-            simulator_item_ = SimulatorItem::findActiveSimulatorItemFor(robot_item);
-            if (!simulator_item_) {
-                // MessageView::mainInstance()->putln("[OptimizeGainPlugin] Simulator item can't be found. Stop reset_timer_");
-                // reset_timer_.stop();
-            }
-        }
+        mapped_region region_eval{shm_eval, read_only};
+        double *eval = static_cast<double*>(region_eval.get_address());
+        for (int i = 0; i < 1; i++)
+            MessageView::mainInstance()->putln(std::string("eval: ") + std::to_string(eval[i]));
     }
 };
 


### PR DESCRIPTION
I don't merge yet.

ResetTimerPlugin以外がreset_timerを持たなくても良いような実装にしてみました．
SimulatorItemが複数あることは考慮していない．

@jskhtakeda
initializeとfinalizeも含めて結構変更したので，確認おねがいします．
また，手元で行っている作業があれば，先にpushしてもらっても構いません．