### PR TITLE
Send signal when simulation reset

### DIFF
--- a/plugins/OptimizeGainPlugin.cpp
+++ b/plugins/OptimizeGainPlugin.cpp
@@ -36,6 +36,8 @@ class OptimizeGainPlugin : public Plugin
 
     virtual bool initialize() override
     {
+        shm_gain.remove(GAIN_SHM);
+        shm_eval.remove(EVAL_SHM);
         shm_gain = shared_memory_object{create_only, GAIN_SHM, read_write};
         shm_gain.truncate(1024);
         shm_eval = shared_memory_object{create_only, EVAL_SHM, read_write};

--- a/plugins/OptimizeGainPlugin.cpp
+++ b/plugins/OptimizeGainPlugin.cpp
@@ -34,7 +34,7 @@ class OptimizeGainPlugin : public Plugin
         require("Body");
     }
 
-    virtual bool initialize() override
+    bool initialize() override
     {
         shm_gain.remove(GAIN_SHM);
         shm_eval.remove(EVAL_SHM);
@@ -51,7 +51,7 @@ class OptimizeGainPlugin : public Plugin
         return true;
     }
 
-    virtual bool finalize() override
+    bool finalize() override
     {
         shm_gain.remove(GAIN_SHM);
         shm_eval.remove(EVAL_SHM);

--- a/plugins/OptimizeGainPlugin.cpp
+++ b/plugins/OptimizeGainPlugin.cpp
@@ -6,16 +6,16 @@
  * @author Hiroki Takeda
  */
 
+#include <string>
+
 #include <cnoid/Plugin>
-#include <cnoid/RootItem>
 #include <cnoid/SimulatorItem>
 #include <cnoid/MessageView>
-#include <cnoid/Timer>
 
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 
-#include <string>
+#include "ResetSimulationPlugin.h"
 
 using namespace boost::interprocess;
 using namespace cnoid;
@@ -43,13 +43,11 @@ class OptimizeGainPlugin : public Plugin
         shm_eval = shared_memory_object{create_only, EVAL_SHM, read_write};
         shm_eval.truncate(1024);
 
-        cnoid::RootItem::instance()->sigItemAdded().connect([this](Item* _item) {
-                SimulatorItemPtr itemptr = dynamic_cast<cnoid::SimulatorItem*>(_item);
-                if (itemptr) {
-                    this->simulator_item_ = itemptr;
-                    this->simulator_item_->sigSimulationFinished().connect([this]() { this->evalNLOPT(); });
-                }
-            });
+        ResetSimulationPlugin* reset_simulation = findResetSimulation();
+        if (reset_simulation) {
+            reset_simulation->sigResetSimulation().connect([this]() { this->evalNLOPT(); });
+        }
+
         return true;
     }
 

--- a/plugins/ResetSimulationPlugin.cpp
+++ b/plugins/ResetSimulationPlugin.cpp
@@ -6,69 +6,54 @@
  * @author Tatsuya Ishikawa
  */
 
-#include <cnoid/Plugin>
-#include <cnoid/RootItem>
-#include <cnoid/SimulatorItem>
 #include <cnoid/MessageView>
-#include <cnoid/Timer>
 #include <cnoid/ToolBar>
 #include <cnoid/SpinBox>
 
+#include "ResetSimulationPlugin.h"
 #include "../util/util.h"
 
 using namespace cnoid;
 
-class ResetSimulationPlugin : public Plugin
+bool ResetSimulationPlugin::initialize()
 {
-    SimulatorItemPtr simulator_item_;
-    Timer reset_timer_;
-    double reset_interval_;
-public:
+    reset_timer_.sigTimeout().connect([this]() { this->resetSimulation(); });
+    reset_timer_.setInterval(100); // 100ms
+    reset_interval_ = 3.0;
 
-    ResetSimulationPlugin() : Plugin("ResetSimulation")
-    {
-    }
+    std::unique_ptr<ToolBar> bar = std::make_unique<ToolBar>("ResetSimulation");
+    bar->setVisibleByDefault(true);
 
-    virtual bool initialize() override
-    {
-        reset_timer_.sigTimeout().connect([this]() { this->resetSimulation(); });
-        reset_timer_.setInterval(100); // 100ms
-        reset_interval_ = 3.0;
+    ToolButton* button = bar->addToggleButton("ResetSimulation");
+    button->sigToggled().connect([this](bool checked) {
+            if (checked) this->reset_timer_.start();
+            else this->reset_timer_.stop();
+        });
 
-        std::unique_ptr<ToolBar> bar = std::make_unique<ToolBar>("ResetSimulation");
-        bar->setVisibleByDefault(true);
+    std::unique_ptr<SpinBox> timeSpin = std::make_unique<SpinBox>();
+    timeSpin->setMaximum(1000000);
+    timeSpin->setValue(reset_interval_);
+    timeSpin->sigValueChanged().connect([this](const int value) { this->reset_interval_ = value; });
+    bar->addWidget(timeSpin.release());
 
-        ToolButton* button = bar->addToggleButton("ResetSimulation");
-        button->sigToggled().connect([this](bool checked) {
-                if (checked) this->reset_timer_.start();
-                else this->reset_timer_.stop();
-            });
+    addToolBar(bar.release());
+    return true;
+}
 
-        std::unique_ptr<SpinBox> timeSpin = std::make_unique<SpinBox>();
-        timeSpin->setMaximum(1000000);
-        timeSpin->setValue(reset_interval_);
-        timeSpin->sigValueChanged().connect([this](const int value) { this->reset_interval_ = value; });
-        bar->addWidget(timeSpin.release());
-
-        addToolBar(bar.release());
-        return true;
-    }
-
-private:
-
-    void resetSimulation()
-    {
-        if (simulator_item_) {
-            if (simulator_item_->simulationTime() > reset_interval_)
-                simulator_item_->startSimulation(true);
-        } else {
-            simulator_item_ = findSimulatorItem("AISTSimulator");
-            if (!simulator_item_) {
-                MessageView::mainInstance()->putln("[ResetSimulationPlugin] Simulator item can't be found. Stop reset_timer_");
-                reset_timer_.stop();
-            }
+void ResetSimulationPlugin::resetSimulation()
+{
+    if (simulator_item_) {
+        if (simulator_item_->simulationTime() > reset_interval_) {
+            sigResetSimulation_();
+            simulator_item_->startSimulation(true);
+        }
+    } else {
+        simulator_item_ = findSimulatorItem("AISTSimulator");
+        if (!simulator_item_) {
+            MessageView::mainInstance()->putln("[ResetSimulationPlugin] Simulator item can't be found. Stop reset_timer_");
+            reset_timer_.stop();
         }
     }
-};
+}
 
 CNOID_IMPLEMENT_PLUGIN_ENTRY(ResetSimulationPlugin)

--- a/plugins/ResetSimulationPlugin.h
+++ b/plugins/ResetSimulationPlugin.h
@@ -26,7 +26,7 @@ public:
     {
     }
 
-    virtual bool initialize() override;
+    bool initialize() override;
     cnoid::SignalProxy<void()> sigResetSimulation() { return sigResetSimulation_; }
 
 private:

--- a/plugins/ResetSimulationPlugin.h
+++ b/plugins/ResetSimulationPlugin.h
@@ -1,0 +1,41 @@
+// -*- mode: C++; coding: utf-8-unix; -*-
+
+/**
+ * @file  ResetSimulationPlugin.h
+ * @author Tatsuya Ishikawa
+ */
+
+#ifndef __RESETSIMULATIONPLUGIN_H__
+#define __RESETSIMULATIONPLUGIN_H__
+
+#include <cnoid/Plugin>
+#include <cnoid/PluginManager>
+#include <cnoid/Signal>
+#include <cnoid/SimulatorItem>
+#include <cnoid/Timer>
+
+class ResetSimulationPlugin : public cnoid::Plugin
+{
+    cnoid::SimulatorItemPtr simulator_item_;
+    cnoid::Timer reset_timer_;
+    double reset_interval_;
+    cnoid::Signal<void()> sigResetSimulation_;
+
+public:
+    ResetSimulationPlugin() : Plugin("ResetSimulation")
+    {
+    }
+
+    virtual bool initialize() override;
+    cnoid::SignalProxy<void()> sigResetSimulation() { return sigResetSimulation_; }
+
+private:
+    void resetSimulation();
+};
+
+ResetSimulationPlugin* findResetSimulation()
+{
+    return dynamic_cast<ResetSimulationPlugin*>(cnoid::PluginManager::instance()->findPlugin("ResetSimulation"));
+}
+
+#endif // __RESETSIMULATIONPLUGIN_H__


### PR DESCRIPTION
sigSimulationFinishedを使うのも良かったのですが，書き方が冗長になる上，resetSimulationが呼ばれた時に実行する関数をsigSimulationFinishedに結びつけるのは間接的で微妙な感じが以前からしていて，resetSimulation時にsignalを送れば良いことに気付いたのでそのようにしました．

またその過程で，プログラムが途中でセグフォるとshared memoryのremoveが呼ばれずに次回createする際失敗するということが分かったので，initializeの最初にremoveすることにしました．
create_onlyではなくopen_or_createだと問題は起こらなさそうですが，意図をハッキリさせたかったのでこんな感じです．